### PR TITLE
Rockets Default Get Missions on View

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
-import { getMissions } from './Redux/missions/missionsSlice';
 import Layout from './components/Layout';
 import Rockets from './routes/Rockets';
 import Missions from './routes/Missions';
@@ -16,17 +15,13 @@ function App() {
     dispatch(rocketItems());
   }, [dispatch]);
 
-  useEffect(() => {
-    dispatch(getMissions());
-  }, [dispatch]);
-
   return (
     <>
       <Routes>
         <Route path="/" element={<Layout />}>
-          <Route path="/" element={<Profile />} />
+          <Route path="/" element={<Rockets />} />
           <Route path="missions" element={<Missions />} />
-          <Route path="rockets" element={<Rockets />} />
+          <Route path="profile" element={<Profile />} />
         </Route>
       </Routes>
     </>

--- a/src/components/HeaderBar.jsx
+++ b/src/components/HeaderBar.jsx
@@ -12,9 +12,9 @@ const HeaderBar = () => (
     </NavLink>
     <nav className="nav-items">
       <ul>
-        <li className="list-item"><NavLink to="rockets" style={{ color: '#000' }}>Rockets</NavLink></li>
+        <li className="list-item"><NavLink to="/" style={{ color: '#000' }}>Rockets</NavLink></li>
         <li className="list-item"><NavLink to="missions" style={{ color: '#000' }}>Missions</NavLink></li>
-        <li className="list-item"><NavLink to="/" style={{ color: '#000' }}>My Profile</NavLink></li>
+        <li className="list-item"><NavLink to="profile" style={{ color: '#000' }}>My Profile</NavLink></li>
       </ul>
     </nav>
   </div>

--- a/src/components/MissionView.jsx
+++ b/src/components/MissionView.jsx
@@ -1,9 +1,22 @@
+import { useSelector, useDispatch } from 'react-redux';
+import React, { useEffect } from 'react';
 import MissionsTable from './MissionsTable';
+import { getMissions } from '../Redux/missions/missionsSlice';
 
-const MissionView = () => (
-  <>
-    <MissionsTable />
-  </>
-);
+const MissionView = () => {
+  const { missions } = useSelector((store) => store.missions);
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (missions.length === 0) {
+      dispatch(getMissions());
+    }
+  }, [missions.length, dispatch]);
+
+  return (
+    <>
+      <MissionsTable />
+    </>
+  );
+};
 
 export default MissionView;


### PR DESCRIPTION
This branch's purpose was to:
Apply corrections to the navigation making Rockets the default view and retrieving missions only once when navigating into missions tab